### PR TITLE
Do not throw away h1 tags anymore

### DIFF
--- a/readability.go
+++ b/readability.go
@@ -633,7 +633,6 @@ func (r *Readability) prepArticle(articleContent *html.Node) {
 	r.cleanConditionally(articleContent, "fieldset")
 	r.clean(articleContent, "object")
 	r.clean(articleContent, "embed")
-	r.clean(articleContent, "h1")
 	r.clean(articleContent, "footer")
 	r.clean(articleContent, "link")
 	r.clean(articleContent, "aside")


### PR DESCRIPTION
Since end of 2020 the main readability project do not throw away the h1 tags anymore.

This PR simply remove the cleaning mechanism for h1 tags.

https://github.com/mozilla/readability/blob/master/CHANGELOG.md#040---2020-12-23